### PR TITLE
test: refactor mock api server to fail on error

### DIFF
--- a/.env
+++ b/.env
@@ -17,4 +17,4 @@ DB_PASS=change-this-sqlpassword
 WIKIBASE_PINGBACK=false
 # wikibase.svc is the internal docker hostname, change this value to the public hostname
 WIKIBASE_HOST=wikibase.svc
-WIKIBASE_PORT=80
+WIKIBASE_PORT=8000

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,18 +1,5 @@
 version: '2'
 services:
-
-  wikibase:
-    networks:
-      default:
-        aliases:
-          - some-cool-internal-hostname.svc
-
-  api:
-    environment:
-      - API_WIKIBASE_DOMAIN=wikibase.svc
-      - API_WDQS_BACKEND=wdqs.svc:9999
-      - WBSTACK_PROXYMAP_INGRESS="some-cool-internal-hostname.svc:80"
-
   wdqs-updater:
     build:
       context: .

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -27,7 +27,7 @@ services:
     environment:
       - WBSTACK_WIKIBASE_SCHEME=http
       - WBSTACK_LOOP_LIMIT=100
-      - WBSTACK_API_ENDPOINT=http://api.svc:3030
+      - WBSTACK_API_ENDPOINT=http://api.svc:3030/getBatches
       - WBSTACK_BATCH_SLEEP=1
       - WIKIBASE_HOST=wikibase.svc
       - HEAP_SIZE=32m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '2'
+version: '3'
+
 services:
   wdqs:
     image: ghcr.io/wbstack/queryservice:main
@@ -31,9 +32,12 @@ services:
       default:
         aliases:
           - api.svc
+    depends_on:
+      wikibase:
+        condition: service_healthy
     environment:
-      - API_WIKIBASE_DOMAIN=localhost
-      - API_WDQS_BACKEND=localhost:9999
+      - API_WIKIBASE_DOMAIN=wikibase.svc
+      - API_WDQS_BACKEND=wdqs.svc:9999
 
   wikibase:
     image: "${WIKIBASE_IMAGE_NAME}"
@@ -48,6 +52,11 @@ services:
       default:
         aliases:
           - wikibase.svc
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/w/api.php"]
+      interval: 1s
+      timeout: 3s
+      retries: 30
     volumes:
       - ./LocalSettings.ci.php:/var/www/html/LocalSettings.d/LocalSettings.override.php
     environment:
@@ -59,7 +68,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASS}
       DB_NAME: ${DB_NAME}
-      WIKIBASEHOST:
+      WIKIBASE_HOST: ${WIKIBASE_HOST}
 
   mysql:
     image: "${MYSQL_IMAGE_NAME}"
@@ -76,6 +85,7 @@ services:
       default:
         aliases:
           - mysql.svc
+
 volumes:
   query-service-data:
   mediawiki-mysql-data:

--- a/seeder/server.js
+++ b/seeder/server.js
@@ -1,41 +1,51 @@
 var http = require('http');
 const wbEdit = require( 'wikibase-edit' )( require( './wikibase-edit.config' ) );
 
-var x = 0
-http.createServer(async function (req, res) {
-    res.writeHead(200, {'Content-Type': 'text/json'});
+http.createServer(function (req, res) {
+    (async () => {
+        switch (req.url) {
+        case '/getBatches':
+            const numEntities = 20;
+            const entities = [];
 
-    numEntities = 20;
-    entities = [];
+            for (let i = 1; i <= numEntities; ++i) {
+                const { entity } = await wbEdit.entity.create({
+                    type: 'item',
+                    labels: {
+                        'en': new Date().toISOString()
+                    },
+                    descriptions: {
+                        'en': new Date().toDateString() + new Date().toISOString()
+                    }
+                });
 
-    for(var i=1; i <= numEntities; ++i){
-        const { entity } = await wbEdit.entity.create({
-            type: 'item',
-            labels: {
-                'en': new Date().toISOString()
-            },
-            descriptions: {
-                'en': new Date().toDateString() + new Date().toISOString()
+                console.log('created item id', entity.id)
+                entities.push(entity.id)
             }
-        });
 
-        console.log('created item id', entity.id)
-        entities.push(entity.id)
-    }
+            console.log(new Date().toISOString());
 
-    x += numEntities;
-    console.log(new Date().toISOString());
+            responseObject = {
+                'entityIds': entities.join(','),
+                'wiki': {
+                    'domain': process.env.API_WIKIBASE_DOMAIN,
+                    'wiki_queryservice_namespace': {
+                        'backend': process.env.API_WDQS_BACKEND,
+                        'namespace': 'wdq'
+                    }
+                },
 
-    responseObject = {
-        'entityIds': entities.join(','),
-        'wiki': {
-            'domain': process.env.API_WIKIBASE_DOMAIN,
-            'wiki_queryservice_namespace': {
-                'backend': process.env.API_WDQS_BACKEND,
-                'namespace': 'wdq'
-            }
-        },
-
-    };
-    res.end(JSON.stringify([responseObject]));
+            };
+            res.writeHead(200, {'Content-Type': 'text/json'});
+            res.end(JSON.stringify([responseObject]));
+        default:
+            res.writeHead(404);
+            res.end('Not found');
+        }
+    })()
+        .catch((err) => {
+            console.error('Failed handling request: %s', err.message);
+            res.writeHead(500);
+            res.end(err.message);
+        })
 }).listen(3030);

--- a/seeder/server.js
+++ b/seeder/server.js
@@ -38,6 +38,7 @@ http.createServer(function (req, res) {
             };
             res.writeHead(200, {'Content-Type': 'text/json'});
             res.end(JSON.stringify([responseObject]));
+            return;
         default:
             res.writeHead(404);
             res.end('Not found');


### PR DESCRIPTION
Connects #139 

The mock api service relies on the `wikibase` service being up. Currently they are racing, and the mock api keeps crashing because of an unhandled promise rejection until `wikibase` is up.

When adding additional logic in #139, this fail-forward approach does not work anymore as the seeding fails to win the race against the retry logic.

This PR does two things:
- prevent the mock api from crashing on errors
- declare inter-service dependencies properly so that api is ready when being called