### PR TITLE
fix: proxymap parameter is not read when run as command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # queryservice-updater
 
+## 0.3.84_3.13 - December 2023
+
+- Proxy Map parameter needs to be initialized when running as command
+
 ## 0.3.84_3.12 - December 2023
 
 - T352656: Support running updater as one off command with command line args

--- a/src/main/java/org/wikidata/query/rdf/tool/WbStackUpdate.java
+++ b/src/main/java/org/wikidata/query/rdf/tool/WbStackUpdate.java
@@ -118,6 +118,7 @@ public final class WbStackUpdate {
 
     public static void setCommandValuesFromEnvOrDie() {
         wbStackUpdaterThreadCount = Integer.parseInt(System.getenv().getOrDefault("WBSTACK_THREAD_COUNT", "10"));
+        wbStackProxyMapIngress = System.getenv("WBSTACK_PROXYMAP_INGRESS");
     }
 
     private static void setSingleUseServicesAndObjects() {


### PR DESCRIPTION
This parameter needs to be read so we can route traffic to wikis internally.